### PR TITLE
Cleanup baselines

### DIFF
--- a/hydra-sim.cabal
+++ b/hydra-sim.cabal
@@ -21,6 +21,7 @@ executable hydra-sim
   other-modules:       HydraSim.Analyse
                      , HydraSim.Channel
                      , HydraSim.DelayedComp
+                     , HydraSim.Examples.Baselines
                      , HydraSim.Examples.Channels
                      , HydraSim.Examples.Nodes
                      , HydraSim.Examples.Txs

--- a/src/HydraSim/Examples/Baselines.hs
+++ b/src/HydraSim/Examples/Baselines.hs
@@ -1,0 +1,158 @@
+{-|
+Module HydraSim.Examples.Baselines
+Description: Baseline scenarios for protocol performance
+-}
+module HydraSim.Examples.Baselines
+  (Baseline (..),
+   Concurrency (..),
+   Scenario (..),
+   tpsTotalBound,
+   baselineTPS,
+   findIntersection,
+   minConfTime
+  )
+where
+
+import HydraSim.Examples.Nodes
+import HydraSim.Examples.Txs
+import HydraSim.DelayedComp (unComp)
+import Data.Time.Clock (DiffTime)
+import HydraSim.Examples.Channels
+import HydraSim.Tx.Mock
+import HydraSim.Types
+import HydraSim.Sized
+import HydraSim.MSig.Mock
+
+data Scenario = FullTrust | HydraUnlimited deriving (Eq, Show, Read)
+data Concurrency = FiniteConc Int | UnlimitedConc deriving (Eq, Show, Read)
+
+type Bandwidth = Integer
+
+-- | Type representing bounds on the transaction rate from different constraints.
+data TPSBound = TPSBound {
+  tpsCpuBound :: Double,
+  tpsBandwidthBound :: Double,
+  -- | We only have a bound from latency if we have finite concurrency
+  -- (otherwise, we can amortise it completely)
+  tpsMLatencyBound :: Maybe Double
+  } deriving (Eq, Show)
+
+-- | Get an overall bound on the transaction rate from a 'TPSBound'
+tpsTotalBound :: TPSBound -> Double
+tpsTotalBound tps = min (tpsConstantBound tps) (tpsBandwidthBound tps)
+
+-- | The part of the bound that does not depend on bandwidth
+tpsConstantBound :: TPSBound -> Double
+tpsConstantBound (TPSBound cpu _bandwidth Nothing) = cpu
+tpsConstantBound (TPSBound cpu _bandwidth (Just latency)) = min cpu latency
+
+-- | Input data for calculating baselines
+data Baseline = Baseline {
+  blScenario :: Scenario,
+  blConc :: Concurrency,
+  blBandwidth :: Bandwidth,
+  blLocations :: [AWSCenters],
+  blAsigTimes :: (DiffTime, DiffTime, DiffTime),
+  blTxType :: Txs
+  }
+
+
+-- | Calculate bound on transaction rate for a given baseline
+baselineTPS :: Baseline -> TPSBound
+baselineTPS bl = TPSBound cpuBound bandwidthBound mlatencyBound
+  where
+    allNodes = fromIntegral $ length (blLocations bl)
+    otherNodes = allNodes - 1
+    (_signTime, _aggregateTime, verifySigTime) = blAsigTimes bl
+    cpuBound = case blScenario bl of
+      FullTrust ->
+        perSecond $ validationTime bl
+      HydraUnlimited ->
+        perSecond $ validationTime bl + verifySigTime
+    bandwidthBound = (perSecond (otherNodes * (capacity bl (ackMsgSize bl + reqMsgSize bl)) / allNodes))
+    mlatencyBound = case blConc bl of
+      UnlimitedConc -> Nothing
+      FiniteConc conc -> Just $
+        perSecond ((maximum . map snd $ networkDelays bl)*2/(fromIntegral conc * allNodes))
+
+-- | Evaluate TPS bound at suitable supporting points, to plot TPS over bandwidth.
+--
+-- Since the bound that depends on the bandwidth is linear, and the others are
+-- constant, we can calculate the point of intersection.
+findIntersection
+  :: Baseline
+  -> (Bandwidth, Bandwidth) -- ^ lower and upper limit
+  -> [(Bandwidth, TPSBound)]
+  -- ^ list of evaluation points. Includes lower and upper limit, and
+  -- intersection point.
+findIntersection bl (lower, upper)
+  | lower > upper = findIntersection bl (upper, lower)
+  | otherwise =
+    let (lowerTPS, upperTPS) = (lowerBl, upperBl)
+    in if tpsBandwidthBound lowerBl < tpsConstantBound lowerBl
+          && tpsBandwidthBound upperBl > tpsConstantBound upperBl
+       then let intersection = tpsConstantBound lowerBl * (fromIntegral lower) / tpsBandwidthBound lowerBl
+            in [(lower, lowerTPS), (round intersection, (toBl $ round intersection)), (upper, upperTPS)]
+       else [(lower, lowerTPS), (upper, upperTPS)]
+  where toBl bw = baselineTPS $ bl {blBandwidth = bw}
+        lowerBl = toBl lower
+        upperBl = toBl upper
+
+-- | Minimal confirmation time for a transaction.
+--
+-- We get this by just adding the times for all actions that need to be
+-- performed for a transaction to be conofirmed, assuming that every resource is
+-- immediately available.
+minConfTime :: Baseline -> [(AWSCenters, DiffTime)]
+minConfTime bl =
+  [ (region, sum [
+        validationTime bl, -- at the issuer
+        capacity bl $ reqMsgSize bl,
+        networkDelay,
+        validationTime bl, -- at each other node (in parallel)
+        signTime,
+        capacity bl $ ackMsgSize bl,
+        networkDelay,
+        aggregateTime,
+        verifySigTime])
+  | (region, networkDelay) <- networkDelays bl]
+  where
+    (signTime, aggregateTime, verifySigTime) = case blScenario bl of
+      FullTrust -> (0,0,0) -- no multisig in full trust model
+      HydraUnlimited -> blAsigTimes bl
+
+capacity :: Baseline -> (Size -> DiffTime)
+capacity bl = kBitsPerSecond $ blBandwidth bl
+
+ackMsgSize :: Baseline -> Size
+ackMsgSize bl = case blScenario bl of
+  FullTrust ->
+      size (NewSn :: HeadProtocol MockTx) + size (TxId 0)
+  HydraUnlimited ->
+      size $ SigAckTx (mtxRef $ sampleTx bl) (sampleSig bl)
+
+reqMsgSize :: Baseline -> Size
+reqMsgSize bl = size $ SigReqTx (sampleTx bl)
+
+sampleSig :: Baseline -> Sig
+sampleSig bl = unComp (ms_sig_tx (simpleMsig $ blAsigTimes bl) (SKey 0) (sampleTx bl))
+
+validationTime :: Baseline -> DiffTime
+validationTime bl = mtxValidationDelay $ sampleTx bl
+
+sampleTx :: Baseline -> MockTx
+sampleTx bl = case blTxType bl of
+  Simple -> cardanoTx (TxId 0) 2
+  Plutus -> plutusTx (TxId 0)
+
+networkDelays :: Baseline -> [(AWSCenters, DiffTime)]
+networkDelays bl = [ (y, maximum
+                       [ getSOrError x y
+                       | x <- blLocations bl
+                       ])
+                   | y <- blLocations bl]
+
+
+
+-- perSecond :: DiffTime -> Double
+-- perSecond t = 1e12 / fromIntegral (diffTimeToPicoseconds t)

--- a/src/HydraSim/Examples/Baselines.hs
+++ b/src/HydraSim/Examples/Baselines.hs
@@ -16,7 +16,7 @@ where
 import HydraSim.Examples.Nodes
 import HydraSim.Examples.Txs
 import HydraSim.DelayedComp (unComp)
-import Data.Time.Clock (DiffTime)
+import Data.Time.Clock (DiffTime, diffTimeToPicoseconds)
 import HydraSim.Examples.Channels
 import HydraSim.Tx.Mock
 import HydraSim.Types
@@ -50,6 +50,7 @@ tpsConstantBound (TPSBound cpu _bandwidth (Just latency)) = min cpu latency
 data Baseline = Baseline {
   blScenario :: Scenario,
   blConc :: Concurrency,
+  -- | network capacity, in kbits/s
   blBandwidth :: Bandwidth,
   blLocations :: [AWSCenters],
   blAsigTimes :: (DiffTime, DiffTime, DiffTime),
@@ -152,7 +153,5 @@ networkDelays bl = [ (y, maximum
                        ])
                    | y <- blLocations bl]
 
-
-
--- perSecond :: DiffTime -> Double
--- perSecond t = 1e12 / fromIntegral (diffTimeToPicoseconds t)
+perSecond :: DiffTime -> Double
+perSecond t = 1e12 / fromIntegral (diffTimeToPicoseconds t)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -6,6 +6,7 @@ import Control.Monad.Class.MonadTime
 import Data.List (intercalate)
 import Data.Semigroup ((<>))
 import HydraSim.Analyse
+import HydraSim.Examples.Baselines
 import HydraSim.Examples.Channels
 import HydraSim.Examples.Nodes
 import HydraSim.Types
@@ -17,7 +18,7 @@ import Data.Time.Clock (DiffTime, picosecondsToDiffTime)
 
 data CLI = CLI {
   regions :: [AWSCenters],
-  networkCapacity :: Natural,
+  networkCapacity :: [Natural],
   txType :: Txs,
   concurrency :: Natural,
   numberTxs :: Natural,
@@ -33,7 +34,7 @@ cli = CLI
   <$> some (argument auto (metavar "NVirginiaAWS | OhioAWS | NCaliforniaAWS | OregonAWS | CanadaAWS | IrelandAWS | LondonAWS | FrankfurtAWS | TokyoAWS | SeoulAWS | SingaporeAWS | SydneyAWS | MumbaiAWS | SaoPauloAWS | GL10"))
   <*> (option auto (short 'b'
                     <> long "bandwidth"
-                    <> value 500
+                    <> value [500, 1000, 2000, 3000, 4000, 5000]
                     <> help "Network bandwidth (inbound and outbound) of the nodes, in kbits/s."))
   <*> (option auto (short 't'
                     <> long "txType"
@@ -74,27 +75,65 @@ main = do
         ( fullDesc
           <> progDesc "Simulations of the Hydra head protocol.")
   opts <- execParser parser
-  let specs = flip map (regions opts) $ \center ->
-        NodeSpec {nodeRegion = center,
-                  nodeNetworkCapacity = fromIntegral $ networkCapacity opts,
-                  nodeTxs = txType opts,
-                  nodeTxConcurrency = fromIntegral $ concurrency opts,
-                  nodeTxNumber = fromIntegral $ numberTxs opts,
-                  nodeSnapStrategy = snapStrategy opts,
-                  nodeASigTime = secondsToDiffTimeTriplet $ asigTime opts
-                 }
   when (verbosity opts > 0) $ print opts
-  (txs, snaps) <- analyseRun (verbosity opts) (runNodes specs)
-  writeCSV opts specs txs snaps
-  when (verbosity opts > 0) $ do
-    let (minConfTime, maxTPS, maxTPS') = performanceLimit specs
-    putStrLn $ concat ["Minimal confirmation time: ", show $ minConfTime]
-    putStrLn $ concat ["Maximal throughput (Hydra Unlimited): ",
-                       show $ maxTPS,
-                       percent (tps txs) maxTPS]
-    putStrLn $ concat ["Maximal throughput (Full Trust): ",
-                       show $ maxTPS',
-                       percent (tps txs) maxTPS']
+  let fp = output opts
+  doesExist <- doesFileExist fp
+  let mode = if doesExist then AppendMode else WriteMode
+  withFile fp mode $ \h -> do
+    when (not doesExist) (hPutStrLn h "t,object,conftime,bandwidth,txtype,conc,regions,node,tps,snapsize,clustersize")
+
+    let baseline scenario = Baseline {
+          blScenario = scenario,
+          blConc = FiniteConc (fromIntegral $ concurrency opts),
+          blBandwidth = fromIntegral $ minimum (networkCapacity opts),
+          blLocations = regions opts,
+          blAsigTimes = secondsToDiffTimeTriplet $ asigTime opts,
+          blTxType = txType opts
+          }
+        baselines = [
+          ("full-trust", baseline FullTrust),
+          ("full-trust-infinte-conc", (baseline FullTrust) {blConc = UnlimitedConc}),
+          ("hydra-unlimited", baseline HydraUnlimited),
+          ("hydra-unlimited-infinte-conc", (baseline HydraUnlimited) {blConc = UnlimitedConc})
+          ]
+    forM_ baselines $ \(scenario, bl) -> do
+      let tpsBound = findIntersection bl (fromIntegral $ minimum (networkCapacity opts),
+                                          fromIntegral $ maximum (networkCapacity opts))
+      forM_ tpsBound $ \(capacity, bound) ->
+        hPutStrLn h $ intercalate ","
+          [showt 0, scenario, "NA", show $ capacity, show $ txType opts, show $ concurrency opts, showCenterList $ regions opts, "NA", show (tpsTotalBound bound), "na", show (length $ regions opts)]
+
+
+
+    forM_ (networkCapacity opts) $ \capacity -> do
+
+      let minConfTimes = minConfTime ((baseline HydraUnlimited) {blBandwidth = fromIntegral capacity})
+      forM_ minConfTimes $ \(region, confTime) -> do
+        hPutStrLn h $ intercalate ","
+          [showt 0, "tx-baseline", showt confTime, show $ capacity, show $ txType opts, show $ concurrency opts, showCenterList $ regions opts, show region, "NA", "NA", show (length $ regions opts)]
+
+
+      let specs = flip map (regions opts) $ \center ->
+            NodeSpec {nodeRegion = center,
+                      nodeNetworkCapacity = fromIntegral capacity,
+                      nodeTxs = txType opts,
+                      nodeTxConcurrency = fromIntegral $ concurrency opts,
+                      nodeTxNumber = fromIntegral $ numberTxs opts,
+                      nodeSnapStrategy = snapStrategy opts,
+                      nodeASigTime = secondsToDiffTimeTriplet $ asigTime opts
+                     }
+      (txs, snaps) <- analyseRun (verbosity opts) (runNodes specs)
+      writeCSV h opts capacity specs txs snaps
+      when (verbosity opts > 0) $ do
+        let tpsUnlimited = baselineTPS (baseline HydraUnlimited)
+            tpsFullTrust = baselineTPS (baseline FullTrust)
+        putStrLn $ concat ["Minimal confirmation time: ", show (minConfTime $ baseline HydraUnlimited)]
+        putStrLn $ concat ["Maximal throughput (Hydra Unlimited): ",
+                           show tpsUnlimited,
+                           percent (tps txs) (tpsTotalBound tpsUnlimited)]
+        putStrLn $ concat ["Maximal throughput (Full Trust): ",
+                           show tpsFullTrust,
+                           percent (tps txs) (tpsTotalBound tpsFullTrust)]
   where
     percent :: Double -> Double -> String
     percent x y = concat [" (", show $ x/y * 100, "%)"]
@@ -105,29 +144,18 @@ secondsToDiffTime = picosecondsToDiffTime . round . (*1e12)
 secondsToDiffTimeTriplet :: (Double, Double, Double) -> (DiffTime, DiffTime, DiffTime)
 secondsToDiffTimeTriplet (a,b,c) = (secondsToDiffTime a, secondsToDiffTime b, secondsToDiffTime c)
 
-writeCSV :: CLI -> [NodeSpec] -> [TxConfirmed] -> [SnConfirmed] -> IO ()
-writeCSV opts specs txs snaps = do
-  let fp = output opts
-      nNodes = length specs
-  doesExist <- doesFileExist fp
-  let mode = if doesExist then AppendMode else WriteMode
-  withFile fp mode $ \h -> do
-        when (not doesExist) (hPutStrLn h "t,object,conftime,bandwidth,txtype,conc,regions,node,tps,snapsize,clustersize")
-        let tpsInRun = tps txs
-        forM_ (drop (discardEdges opts) . reverse . drop (discardEdges opts) $ txs) $ \tx -> case tx of
-          TxConfirmed node t dt -> hPutStrLn h $ intercalate ","
-            [showt (timeToDiffTime t), "tx", showt dt, show $ networkCapacity opts, show $ txType opts, show $ concurrency opts, showCenterList $ regions opts, node, show tpsInRun, "NA", show nNodes]
-          TxUnconfirmed _ _ -> return ()
-        forM_ snaps $ \snap -> case snap of
-          SnConfirmed node size t dt -> hPutStrLn h $ intercalate ","
-            [showt (timeToDiffTime t), "snap", showt dt, show $ networkCapacity opts, show $ txType opts, show $ concurrency opts, showCenterList $ regions opts, node, show tpsInRun, show size, show nNodes]
-          SnUnconfirmed _ _ _ -> return ()
-        let (minConfTimes, maxTPS, maxTPS') = performanceLimit specs
-        forM_ minConfTimes $ \(region, minConfTime) -> do
-          hPutStrLn h $ intercalate ","
-            [showt 0, "tx-baseline", showt minConfTime, show $ networkCapacity opts, show $ txType opts, show $ concurrency opts, showCenterList $ regions opts, show region, show $ maxTPS, "NA", show nNodes]
-          hPutStrLn h $ intercalate ","
-            [showt 0, "tx-baseline2", showt minConfTime, show $ networkCapacity opts, show $ txType opts, show $ concurrency opts, showCenterList $ regions opts, show region, show $ maxTPS', "NA", show nNodes]
+writeCSV :: Handle -> CLI -> Natural -> [NodeSpec] -> [TxConfirmed] -> [SnConfirmed] -> IO ()
+writeCSV h opts capacity specs txs snaps = do
+  let nNodes = length specs
+      tpsInRun = tps txs
+  forM_ (drop (discardEdges opts) . reverse . drop (discardEdges opts) $ txs) $ \tx -> case tx of
+    TxConfirmed node t dt -> hPutStrLn h $ intercalate ","
+      [showt (timeToDiffTime t), "tx", showt dt, show $ capacity, show $ txType opts, show $ concurrency opts, showCenterList $ regions opts, node, show tpsInRun, "NA", show nNodes]
+    TxUnconfirmed _ _ -> return ()
+  forM_ snaps $ \snap -> case snap of
+    SnConfirmed node size t dt -> hPutStrLn h $ intercalate ","
+      [showt (timeToDiffTime t), "snap", showt dt, show $ capacity, show $ txType opts, show $ concurrency opts, showCenterList $ regions opts, node, show tpsInRun, show size, show nNodes]
+    SnUnconfirmed _ _ _ -> return ()
 
 showt :: DiffTime -> String
 showt = show . diffTimeToSeconds


### PR DESCRIPTION
Moved baselines to their own module, and changed them to be more systematic.

Both baselines can now either assume unlimited concurrency (which is equivalent to setting the roundtrip time to zero, since you can amortise perfectly), or a finite concurrency.

The Hydra Unlimited baseline also features snapshots (for Full Trust, it doesn't really make sense to agree on snapshots, since you're not trying to achieve consensus in the first place.