### PR TITLE
Fix protocol selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /dist-newstyle/
 *~
 .direnv/
-.direnv/
+.cabal.project.local

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,7 @@
 packages: .
 
 -- Always show detailed output for tests
+tests: True
 test-show-details: direct
 
 source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -7,14 +7,9 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
   tag: 5946ae86d7c205049a956d64b0fc92b11e2b2b0d
-  subdir: io-sim-classes
-  --sha256: 167fxfpqnp824i224ja461h36ya7c8qfjy2bx7pjywv861069d7y
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 5946ae86d7c205049a956d64b0fc92b11e2b2b0d
-  subdir: io-sim
+  subdir:
+    io-sim
+    io-sim-classes
   --sha256: 167fxfpqnp824i224ja461h36ya7c8qfjy2bx7pjywv861069d7y
 
 source-repository-package

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,2 +1,0 @@
-tests: True
-       

--- a/experiments/large-cluster.sh
+++ b/experiments/large-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # A simpler experiment with larger number of nodes
 mkdir -p csv pdf
 

--- a/experiments/run.sh
+++ b/experiments/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 mkdir -p csv pdf
 
 export locations=('FrankfurtAWS FrankfurtAWS FrankfurtAWS' 'IrelandAWS FrankfurtAWS LondonAWS' 'OregonAWS FrankfurtAWS TokyoAWS')

--- a/shell.nix
+++ b/shell.nix
@@ -1,33 +1,37 @@
 # shell.nix
-{pkgs ? import <nixpkgs> {} }:
-
+{ pkgs ? import <nixpkgs> { } }:
 let
   hsPkgs = import ./default.nix { };
 in
-  hsPkgs.shellFor {
-    # Include only the *local* packages of your project.
-    packages = ps: with ps; [
-      hydra-sim
-    ];
+hsPkgs.shellFor {
+  # Include only the *local* packages of your project.
+  packages = ps: with ps; [
+    hydra-sim
+  ];
 
-    # Builds a Hoogle documentation index of all dependencies,
-    # and provides a "hoogle" command to search the index.
-#    withHoogle = true;
+  # Builds a Hoogle documentation index of all dependencies,
+  # and provides a "hoogle" command to search the index.
+  #    withHoogle = true;
 
-    # You might want some extra tools in the shell (optional).
+  # You might want some extra tools in the shell (optional).
 
-    # Some common tools can be added with the `tools` argument
-    tools = { cabal = "3.2.0.0"; hlint = "2.2.11"; haskell-language-server = "1.0.0.0"; ormolu = "latest" ; };
-    # See overlays/tools.nix for more details
+  # Some common tools can be added with the `tools` argument
+  tools = {
+    cabal = "3.2.0.0";
+    hlint = "latest";
+    haskell-language-server = "latest";
+    ormolu = "latest";
+  };
+  # See overlays/tools.nix for more details
 
-    # Some you may need to get some other way.
-    buildInputs = with pkgs.haskellPackages;
-      [ ghcid
-        hspec-discover
-      ];
+  # Some you may need to get some other way.
+  buildInputs = with pkgs.haskellPackages; [
+    ghcid
+    hspec-discover
+  ];
 
-    # Setting it to true prevents cabal from choosing alternate plans, so that
-    # *all* dependencies are provided by Nix.
-    # However, this breaks hspec-discover so ¯\_(ツ)_/¯
-    exactDeps = false;
-  }
+  # Setting it to true prevents cabal from choosing alternate plans, so that
+  # *all* dependencies are provided by Nix.
+  # However, this breaks hspec-discover so ¯\_(ツ)_/¯
+  exactDeps = false;
+}

--- a/src/HydraSim/Options.hs
+++ b/src/HydraSim/Options.hs
@@ -47,29 +47,33 @@ cli =
                 auto
                 ( short 'b'
                     <> long "bandwidth"
-                    <> value (networkCapacity defaultOptions)
                     <> help "Network bandwidth (inbound and outbound) of each node, in kbits/s. It is "
+                    <> value (networkCapacity defaultOptions)
+                    <> showDefault
                 )
             <*> option
                 auto
                 ( short 't'
                     <> long "txType"
                     <> metavar "Plutus | Simple"
-                    <> value (txType defaultOptions)
                     <> help "Types of transactions to send."
+                    <> value (txType defaultOptions)
+                    <> showDefault
                 )
             <*> option
                 auto
                 ( short 'c'
                     <> long "concurrency"
-                    <> value (concurrency defaultOptions)
                     <> help "Determines how many transaction any node will send before older transactions are confirmed."
+                    <> value (concurrency defaultOptions)
+                    <> showDefault
                 )
             <*> option
                 auto
                 ( short 'n'
-                    <> value (numberTxs defaultOptions)
                     <> help "Number of transactions each node will send."
+                    <> value (numberTxs defaultOptions)
+                    <> showDefault
                 )
             <*> option
                 auto
@@ -77,6 +81,7 @@ cli =
                     <> help "Sets the strategy for when to create snapshots"
                     <> metavar "NoSnapshots | SnapAfter N"
                     <> value (snapStrategy defaultOptions)
+                    <> showDefault
                 )
             <*> option
                 auto
@@ -84,6 +89,7 @@ cli =
                     <> help "Sets the strategy for when to create snapshots"
                     <> metavar "NoSnapshots | SnapAfter N"
                     <> value (baselineSnapshots defaultOptions)
+                    <> showDefault
                 )
             <*> option
                 auto
@@ -91,6 +97,7 @@ cli =
                     <> help "Sets the flavor of the head protocol to use by nodes"
                     <> metavar "Vanilla | CoordinatedVanilla"
                     <> value (protocolFlavor defaultOptions)
+                    <> showDefault
                 )
             <*> option
                 auto
@@ -98,12 +105,14 @@ cli =
                     <> help "time (in seconds) for MSig operations (signing, aggregating, validating)"
                     <> value (asigTime defaultOptions)
                     <> metavar "(T_SIGN, T_AGGREGATE, T_VERIFY)"
+                    <> showDefault
                 )
             <*> strOption
                 ( short 'o'
                     <> long "output"
                     <> help "Write output to CSV file"
                     <> value (output defaultOptions)
+                    <> showDefault
                 )
             <*> option
                 auto
@@ -111,11 +120,13 @@ cli =
                     <> help "When writing data for confirmation time, discard the first and last N samples (allow for warmup/cooldown)"
                     <> metavar "N"
                     <> value (discardEdges defaultOptions)
+                    <> showDefault
                 )
             <*> option
                 auto
                 ( short 'v'
                     <> long "verbosity"
-                    <> value (verbosity defaultOptions)
                     <> help "How much to print on the command line. Set it to 4 or more to print debug messages."
+                    <> value (verbosity defaultOptions)
+                    <> showDefault
                 )

--- a/src/HydraSim/Types.hs
+++ b/src/HydraSim/Types.hs
@@ -275,7 +275,7 @@ data SendMessage tx =
 type HStateTransformer tx = HState tx -> HeadProtocol tx -> Decision tx
 
 -- | A function that handles incoming messages for a node.
-type ProtocolHandler tx = NodeConf tx -> NodeId ->  HStateTransformer tx
+type ProtocolHandler tx = NodeConf tx -> NodeId -> HStateTransformer tx
 
 -- | Tracing how the node state changes as transactions are acknowledged, and
 -- snapshots are produced.


### PR DESCRIPTION
The `handleMessage` of the simple protocol was used always. Changed that to use it from the `NodeSpec` record instead.

Also various minor changes I had on this branch before:
* Show default command line options
* Fix shebangs to not use /bin/bash (important for NixOS)
* Remove and ignore cabal.project.local
* Use 'latest' hackage packages in shell.nix to get more likely cache hits with hydra.iohk.io
* Reduce number of 'source-repository-package' in cabal.project